### PR TITLE
Bepress importer can now handle photographic articles

### DIFF
--- a/management/commands/import_bepress_archive.py
+++ b/management/commands/import_bepress_archive.py
@@ -34,6 +34,11 @@ class Command(BaseCommand):
             '--section-field',
             help="Custom field used for denoting the section name",
         )
+        parser.add_argument(
+            '--path',
+            help=("Only import articles found under the given bepress path."
+                " Usefull for importing a single volume or article.")
+        )
         parser.add_argument('--dry-run', action="store_true", default=False)
 
     def handle(self, *args, **options):
@@ -42,6 +47,7 @@ class Command(BaseCommand):
             utils.import_archive(
                 options["archive_name"], options["stamped"],
                 site, options["structure_type"],
+                import_path=options["path"],
             )
         else:
             site = journal_models.Journal.objects.get(code=options["site_code"])
@@ -54,4 +60,5 @@ class Command(BaseCommand):
             utils.import_archive(
                 options["archive_name"], options["stamped"], site,
                 options["structure_type"], section, options["section_field"],
+                import_path=options["path"],
             )

--- a/management/commands/import_bepress_from_oai.py
+++ b/management/commands/import_bepress_from_oai.py
@@ -12,10 +12,41 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('oai-url')
+        parser.add_argument(
+            '--set', '-s',
+            default=None,
+            help="The set identifier by which to filter the OAI feed",
+        )
+        parser.add_argument(
+            '--identifier', '-i',
+            default=None,
+            help="URI identifier for retrieving a single document from the OAI",
+        )
+
+    def handle(self, *args, **options):
+        if options["structure_type"] == "books":
+            site = Press.objects.first()
+            utils.import_archive(
+                options["archive_name"], options["stamped"],
+                site, options["structure_type"],
+            )
+        else:
+            site = journal_models.Journal.objects.get(code=options["site_code"])
+            section = None
+            if options.get("default_section"):
+                section = sub_models.Section.objects.get(
+                    id=options["default_section"],
+                    journal=site,
+                )
+            utils.import_archive(
+                options["archive_name"], options["stamped"], site,
+                options["structure_type"], section, options["section_field"],
+            )
+
 
     def handle(self, *args, **options):
         client = Sickle(options["oai-url"])
-        import_from_oai(client)
+        import_from_oai(client, set_=options.get("set"))
         print("Done.")
         print(
             "You can now import the loaded archives with "

--- a/oai.py
+++ b/oai.py
@@ -16,16 +16,30 @@ logger = get_logger(__name__)
 METADATA_PREFIX = "document-export"
 
 
-def import_from_oai(client):
+def import_from_oai(client, set_=None, identifier=None):
     """ Imports bepress metadata from a given OAI client
     Metadata is written as XML to the location defined in settings as
     BEPRESS_PATH
     :param client: an instance of sicle.app.Sickle
     """
-    record_iterator = client.ListRecords(metadataPrefix=METADATA_PREFIX)
-    for record in record_iterator:
-        logger.info("Processing %s", record.header)
+    if identifier:
+        record = client.ListRecords(
+            metadataPrefix=METADATA_PREFIX,
+            identifier="identifier",
+        )
         generate_metadata_from_oai_record(record.raw)
+    else:
+        list_records_kwargs = {}
+        if set_:
+            list_records_kwargs["set"] = set_
+
+        record_iterator = client.ListRecords(
+            metadataPrefix=METADATA_PREFIX,
+            **list_records_kwargs,
+        )
+        for record in record_iterator:
+            logger.info("Processing %s", record.header)
+            generate_metadata_from_oai_record(record.raw)
 
 
 def generate_metadata_from_oai_record(record):

--- a/utils.py
+++ b/utils.py
@@ -611,11 +611,16 @@ def add_image_galley(image_file, article):
     article.galley_set.add(galley)
 
 
-def import_archive(folder, stamped, site, struct, default_section=None, section_key=None):
+def import_archive(
+    folder, stamped, site, struct,
+    default_section=None, section_key=None, import_path=None,
+):
     book = None
     logger.set_prefix(site.code)
     path = os.path.join(BEPRESS_PATH, folder)
     for root, dirs, files_ in os.walk(path):
+        if import_path and import_path not in root:
+            continue
         try:
             if 'metadata.xml' in files_:
                 metadata_path = os.path.join(root, 'metadata.xml')

--- a/utils.py
+++ b/utils.py
@@ -210,7 +210,7 @@ def metadata_license(soup, article):
         license_url = field.value.string
         if license_url.endswith("/"):
             license_url = license_url[:-1]
-        license_url.replace("http:", "https:")
+        license_url = license_url.replace("http:", "https:")
         article.license, c = submission_models.Licence.objects.get_or_create(
             journal=article.journal,
             url=license_url,
@@ -489,6 +489,29 @@ def add_media_galley(soup, article):
     url_soup = soup.fields.find(attrs={"name": "multimedia_url"})
     if format_soup and format_soup.value.string == "youtube":
         add_youtube_galley(url_soup.value.string, article)
+    native_url_soup = getattr(soup, "native-url", None)
+    if native_url_soup:
+        native_url = native_url_soup.string
+        # Make a head request to check the mime
+        response = requests.head(native_url, allow_redirects=True)
+        mimetype = get_content_type_from_headers(response)
+        # image/jpg missing from core image f
+        if mimetype and mimetype in files.IMAGE_MIMETYPES:
+            logger.info("Found native-url to be an image, importing as galley")
+            logger.info(native_url)
+            add_image_as_galley(native_url, article)
+
+
+def add_image_as_galley(url, article):
+    response = requests.get(url)
+    if response.ok:
+        filename = get_filename_from_headers(response)
+        django_file = SimpleUploadedFile(filename, response.content)
+        galley = add_image_galley(django_file, article)
+
+    else:
+        logger.error("Failed to retrieve image from url: %s" % response.status)
+
 
 
 def add_youtube_galley(youtube_url, article):
@@ -570,6 +593,24 @@ def add_html_galley(html_galley, article):
     article.galley_set.add(galley)
 
 
+def add_image_galley(image_file, article):
+    if article.galley_set.filter(type="image").exists():
+        return
+    saved_file = files.save_file_to_article(
+            image_file, article,
+            owner=None,
+            label="image",
+            is_galley=True,
+    )
+    galley = Galley.objects.create(
+            article=article,
+            file=saved_file,
+            type="image",
+            label="Image",
+    )
+    article.galley_set.add(galley)
+
+
 def import_archive(folder, stamped, site, struct, default_section=None, section_key=None):
     book = None
     logger.set_prefix(site.code)
@@ -583,7 +624,7 @@ def import_archive(folder, stamped, site, struct, default_section=None, section_
                     book, chapter = import_book_chapter(soup, site)
                 else:
                     import_article(
-                        soup, root, folder, stamped, site,
+                        soup, root, files_, folder, stamped, site,
                         struct, default_section, section_key,
                     )
 
@@ -600,7 +641,7 @@ def import_archive(folder, stamped, site, struct, default_section=None, section_
         book.save()
 
 
-def import_article(soup, root, folder, stamped, site, struct, default_section, section_key):
+def import_article(soup, root, files_, folder, stamped, site, struct, default_section, section_key,):
     path = os.path.join(BEPRESS_PATH, folder)
     article = create_article_record(
         folder, soup, site, default_section, section_key)


### PR DESCRIPTION
When an article points to an image as its `native-url`, it is retrieved and stored as a galley.
If the Janeway install runs on v.1.4.2.1+, the galley will be rendered in the HTML view of the article